### PR TITLE
Add x402 payment tool example — handle HTTP 402 in agent loops

### DIFF
--- a/examples/x402_payment_tool/README.md
+++ b/examples/x402_payment_tool/README.md
@@ -1,0 +1,169 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# x402 Payment Tool for NeMo Agent Toolkit
+
+## Overview
+
+### The Problem
+
+AI agents increasingly need to interact with paid APIs and services autonomously. When an agent encounters an HTTP 402 (Payment Required) response, it needs to:
+
+- Evaluate whether the data justifies the cost
+- Construct and authorize a payment
+- Retry the request with payment proof attached
+- Track spending against configurable budget limits
+
+Unlike regular API errors, payment operations are **irreversible** — a bug doesn't just waste a retry, it transfers real value. This requires security guarantees beyond what standard tool integrations provide.
+
+### The Solution
+
+This example demonstrates a payment-enabled tool for NeMo Agent Toolkit that handles [x402](https://github.com/coinbase/x402) payment negotiation within an agent loop. The x402 protocol uses HTTP's previously unused 402 status code to enable machine-to-machine payments.
+
+### How It Works
+
+1. **Agent requests data** from a paid API via the payment tool
+2. **API responds with 402** including payment requirements (amount, recipient, token)
+3. **Tool evaluates the cost** against the agent's spending policy
+4. **Wallet signs the payment** (signing key isolated from the agent process)
+5. **Tool retries with payment proof** attached as an HTTP header
+6. **Agent receives the data** and continues its task
+
+### Key Security Properties
+
+| Property | Implementation | Why It Matters |
+|----------|---------------|----------------|
+| **Bounded blast radius** | On-chain spending policies (per-tx cap, daily limit) | A hallucinating LLM cannot drain the wallet |
+| **Key isolation** | Wallet signer runs in a separate process | MCP server compromise doesn't leak private keys |
+| **Allowlisted recipients** | Only pre-approved addresses can receive payments | Prevents payments to arbitrary addresses |
+| **Audit trail** | Every payment logged with tx hash, amount, recipient | Full accountability for autonomous spending |
+
+## Architecture
+
+```
+┌─────────────────────────┐
+│   NeMo Agent Toolkit    │
+│   (ReAct Agent Loop)    │
+│                         │
+│  ┌───────────────────┐  │
+│  │  x402 Payment     │  │     ┌──────────────┐
+│  │  Tool             │──┼────▶│  Paid API    │
+│  │                   │  │     │  (returns 402)│
+│  │  - cost eval      │  │     └──────────────┘
+│  │  - budget check   │  │
+│  │  - retry w/ proof  │  │
+│  └────────┬──────────┘  │
+│           │              │
+└───────────┼──────────────┘
+            │
+   ┌────────▼────────┐
+   │  Wallet Signer  │
+   │  (isolated      │
+   │   process)      │
+   │                 │
+   │  - private key  │
+   │  - spend policy │
+   │  - tx signing   │
+   └─────────────────┘
+```
+
+## Prerequisites
+
+- Python >= 3.11
+- NeMo Agent Toolkit >= 1.4.0
+- An Ethereum wallet with USDC (Base network recommended for low fees)
+- Access to an x402-enabled API endpoint (or use the included mock server for testing)
+
+## Quick Start
+
+### 1. Install
+
+```bash
+cd examples/x402_payment_tool
+pip install -e .
+```
+
+### 2. Configure
+
+```bash
+# Copy the example config
+cp src/nat_x402_payment/configs/payment-agent.example.yml src/nat_x402_payment/configs/payment-agent.yml
+
+# Set your wallet private key (NEVER commit this)
+export WALLET_PRIVATE_KEY="your-private-key-here"
+
+# Or use a separate signer process (recommended for production)
+export WALLET_SIGNER_URL="http://localhost:8900"
+```
+
+### 3. Run with Mock Server (Testing)
+
+```bash
+# Start the mock x402 server
+python scripts/mock_x402_server.py &
+
+# Run the agent
+nat run --config src/nat_x402_payment/configs/payment-agent.yml
+```
+
+### 4. Run with Real x402 API
+
+```bash
+# Update payment-agent.yml with your x402 API endpoint
+nat run --config src/nat_x402_payment/configs/payment-agent.yml
+```
+
+## Configuration
+
+### Spending Policy
+
+Edit `configs/payment-agent.yml` to set spending limits:
+
+```yaml
+payment_tool:
+  max_per_transaction: 0.10    # Max USDC per single payment
+  max_daily_spend: 5.00        # Daily spending cap
+  allowed_recipients:           # Allowlisted payment recipients
+    - "0x..."                   # Your x402 API provider
+  require_confirmation: false   # Set true for human-in-the-loop
+```
+
+### Wallet Isolation Modes
+
+| Mode | Security | Setup Complexity | Use Case |
+|------|----------|-----------------|----------|
+| **Inline** | Basic | Low | Development/testing |
+| **Separate process** | High | Medium | Production |
+| **Hardware signer** | Highest | High | Enterprise |
+
+## Example Output
+
+```
+Agent: I need to fetch premium market data for the user's query.
+Tool:  Requesting https://api.example.com/v1/market-data?symbol=NVDA
+Tool:  Received HTTP 402 — Payment Required
+Tool:  Cost: 0.05 USDC | Budget remaining: 4.95 USDC | Policy: APPROVED
+Tool:  Payment signed (tx: 0xabc...def) — retrying with proof
+Tool:  Data received (200 OK)
+Agent: Based on the premium market data, NVDA is currently trading at...
+```
+
+## References
+
+- [x402 Protocol (Coinbase)](https://github.com/coinbase/x402) — HTTP 402 payment standard
+- [agent-wallet-sdk](https://github.com/up2itnow0822/agent-wallet-sdk) — Non-custodial agent wallets with spending policies
+- [agentpay-mcp](https://github.com/up2itnow0822/agentpay-mcp) — MCP payment server implementation

--- a/examples/x402_payment_tool/pyproject.toml
+++ b/examples/x402_payment_tool/pyproject.toml
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[build-system]
+build-backend = "setuptools.build_meta"
+requires = ["setuptools >= 64", "setuptools-scm>=8"]
+
+[tool.setuptools_scm]
+git_describe_command = "git describe --long --first-parent"
+root = "../.."
+
+[project]
+name = "nat_x402_payment"
+dynamic = ["version"]
+dependencies = [
+    "nvidia-nat[langchain]>=1.4.0a0,<1.5.0",
+    "httpx>=0.27.0",
+    "eth-account>=0.13.0",
+    "pyyaml>=6.0",
+]
+requires-python = ">=3.11,<3.14"
+description = "x402 payment-enabled tool for NeMo Agent Toolkit — handle HTTP 402 payment negotiation in agent loops"
+keywords = ["ai", "payments", "x402", "nvidia", "agents", "wallet"]
+classifiers = ["Programming Language :: Python"]
+
+[project.entry-points.'nat.components']
+nat_x402_payment = "nat_x402_payment.register"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/examples/x402_payment_tool/scripts/mock_paid_api.py
+++ b/examples/x402_payment_tool/scripts/mock_paid_api.py
@@ -1,0 +1,107 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Mock paid API server for testing the x402 payment tool.
+
+This server simulates an API that requires x402 payments:
+- GET /data          → Returns 402 with payment requirements
+- GET /data + X-Payment header → Returns premium data (200)
+- GET /free          → Returns free data (200, no payment needed)
+
+Usage:
+    python scripts/mock_paid_api.py
+    # Server runs on http://localhost:8402
+"""
+
+from __future__ import annotations
+
+import json
+import time
+import uuid
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+MOCK_RECIPIENT = "0x1234567890abcdef1234567890abcdef12345678"
+MOCK_TOKEN = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"  # USDC on Base
+PORT = 8402
+
+
+class PaidAPIHandler(BaseHTTPRequestHandler):
+    """HTTP handler that simulates x402 payment flows."""
+
+    def do_GET(self) -> None:
+        if self.path == "/free":
+            self._send_json(200, {"data": "This is free data. No payment required."})
+            return
+
+        if self.path == "/data":
+            # Check for payment proof
+            payment = self.headers.get("X-Payment")
+            if payment:
+                # Payment received — return premium data
+                self._send_json(
+                    200,
+                    {
+                        "data": {
+                            "title": "Premium Market Analysis",
+                            "summary": "BTC showing strong support at $84k with institutional "
+                            "accumulation. ETH/BTC ratio recovering. AI token sector "
+                            "outperforming market by 340% YTD.",
+                            "confidence": 0.87,
+                            "generated_at": time.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                        },
+                        "payment_status": "accepted",
+                    },
+                )
+            else:
+                # No payment — return 402 with x402 requirements
+                self._send_json(
+                    402,
+                    {
+                        "payment": {
+                            "amount": 10000,  # 0.01 USDC (6 decimals)
+                            "recipient": MOCK_RECIPIENT,
+                            "token": MOCK_TOKEN,
+                            "network": "base",
+                            "description": "Premium market analysis report",
+                            "nonce": uuid.uuid4().hex,
+                            "expires_at": int(time.time()) + 300,
+                        }
+                    },
+                )
+            return
+
+        self._send_json(404, {"error": "Not found"})
+
+    def _send_json(self, status: int, body: dict) -> None:
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps(body, indent=2).encode())
+
+    def log_message(self, format: str, *args: object) -> None:
+        """Override to add payment status to logs."""
+        print(f"[MOCK API] {args[0]}")
+
+
+def main() -> None:
+    server = HTTPServer(("localhost", PORT), PaidAPIHandler)
+    print(f"Mock paid API running on http://localhost:{PORT}")
+    print(f"  GET /data  → 402 (requires payment) or 200 (with payment)")
+    print(f"  GET /free  → 200 (always free)")
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/x402_payment_tool/scripts/mock_x402_server.py
+++ b/examples/x402_payment_tool/scripts/mock_x402_server.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Mock x402 server for testing the payment tool.
+
+Simulates a paid API that:
+- Returns 402 with x402 payment requirements for unauthenticated requests
+- Returns 200 with mock data when valid payment proof is provided
+
+Usage:
+    python scripts/mock_x402_server.py
+    # Server runs on http://localhost:8402
+"""
+
+import json
+from http.server import HTTPServer, BaseHTTPRequestHandler
+
+MOCK_DATA = {
+    "market_data": {
+        "symbol": "NVDA",
+        "price": 142.50,
+        "volume": 45_000_000,
+        "change_24h": 3.2,
+        "source": "premium-data-provider",
+        "timestamp": "2026-03-18T12:00:00Z",
+    }
+}
+
+PAYMENT_REQUIREMENTS = {
+    "x402Version": 1,
+    "accepts": [
+        {
+            "scheme": "exact",
+            "network": "base",
+            "maxAmountRequired": "50000",  # 0.05 USDC (6 decimals)
+            "resource": "http://localhost:8402/v1/market-data",
+            "description": "Premium market data access",
+            "mimeType": "application/json",
+            "payTo": "0x1234567890abcdef1234567890abcdef12345678",
+            "maxTimeoutSeconds": 300,
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",  # USDC on Base
+        }
+    ],
+}
+
+MOCK_RECIPIENT = "0x1234567890abcdef1234567890abcdef12345678"
+
+
+class X402Handler(BaseHTTPRequestHandler):
+    def do_GET(self):  # noqa: N802
+        if self.path.startswith("/v1/market-data"):
+            payment_header = self.headers.get("X-PAYMENT", "")
+
+            if payment_header:
+                # Validate payment proof (mock: just check it's non-empty JSON)
+                try:
+                    payment = json.loads(payment_header)
+                    if payment.get("payTo") == MOCK_RECIPIENT:
+                        self.send_response(200)
+                        self.send_header("Content-Type", "application/json")
+                        self.end_headers()
+                        self.wfile.write(json.dumps(MOCK_DATA).encode())
+                        return
+                except (json.JSONDecodeError, KeyError):
+                    pass
+
+                # Invalid payment
+                self.send_response(400)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(json.dumps({"error": "Invalid payment proof"}).encode())
+                return
+
+            # No payment — return 402
+            self.send_response(402)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps(PAYMENT_REQUIREMENTS).encode())
+            return
+
+        # 404 for unknown paths
+        self.send_response(404)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps({"error": "Not found"}).encode())
+
+    def log_message(self, format, *args):
+        """Custom log format."""
+        print(f"[x402-mock] {args[0]}")
+
+
+def main():
+    port = 8402
+    server = HTTPServer(("localhost", port), X402Handler)
+    print(f"Mock x402 server running on http://localhost:{port}")
+    print(f"  GET /v1/market-data → 402 (requires payment)")
+    print(f"  GET /v1/market-data + X-PAYMENT header → 200 (mock data)")
+    print()
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\nShutting down.")
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/x402_payment_tool/src/nat_x402_payment/__init__.py
+++ b/examples/x402_payment_tool/src/nat_x402_payment/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/examples/x402_payment_tool/src/nat_x402_payment/configs/payment-agent.example.yml
+++ b/examples/x402_payment_tool/src/nat_x402_payment/configs/payment-agent.example.yml
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# x402 Payment Tool — Agent Configuration
+# Copy to payment-agent.yml and customize for your deployment
+
+agent:
+  type: react
+  llm:
+    model: meta/llama-3.3-70b-instruct  # Or any NIM-compatible model
+    temperature: 0.1
+  tools:
+    - fetch_paid_api  # x402 payment-enabled fetch tool
+
+# Payment tool configuration (also settable via environment variables)
+payment_tool:
+  # Per-transaction limit in USDC
+  max_per_transaction: 0.10
+
+  # Daily spending cap in USDC
+  max_daily_spend: 5.00
+
+  # Allowlisted payment recipient addresses (empty = allow all)
+  allowed_recipients: []
+
+  # Require human confirmation before each payment
+  require_confirmation: false
+
+  # Wallet mode: "inline" (dev) or "remote" (production)
+  # Inline: set WALLET_PRIVATE_KEY env var
+  # Remote: set WALLET_SIGNER_URL env var
+  wallet_mode: inline

--- a/examples/x402_payment_tool/src/nat_x402_payment/configs/payment-agent.yml.example
+++ b/examples/x402_payment_tool/src/nat_x402_payment/configs/payment-agent.yml.example
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Example configuration for an agent with x402 payment capabilities.
+# Copy this file to payment-agent.yml and customize.
+
+agent:
+  name: payment-enabled-agent
+  description: An agent that can access paid APIs using x402 payments
+  
+  # LLM configuration — uses NVIDIA NIM
+  llm:
+    model: meta/llama-3.3-70b-instruct
+    api_base: https://integrate.api.nvidia.com/v1
+    # Set NVIDIA_API_KEY environment variable
+
+  tools:
+    - paid_api_request  # Registered via nat.components entry point
+
+# Payment configuration
+payment:
+  # Spending limits — enforced BEFORE any payment is signed
+  max_per_transaction_usd: 1.00
+  max_daily_usd: 10.00
+  
+  # Allowlisted recipient addresses (leave empty to allow all)
+  allowed_recipients: []
+  
+  # If true, agent asks user for confirmation before each payment
+  require_confirmation: false
+  
+  # Set to true for testing without real blockchain transactions
+  mock: true
+  
+  # Network: "base" for mainnet, "base-sepolia" for testnet
+  network: base-sepolia

--- a/examples/x402_payment_tool/src/nat_x402_payment/payment_tool.py
+++ b/examples/x402_payment_tool/src/nat_x402_payment/payment_tool.py
@@ -1,0 +1,174 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Payment-enabled API tool for NeMo Agent Toolkit.
+
+This tool wraps HTTP requests to paid APIs that use the x402 protocol.
+When a 402 response is received, it evaluates the spending policy,
+signs a payment proof, and retries the request.
+
+Usage in a NeMo Agent Toolkit config:
+
+    tools:
+      - name: paid_api
+        type: nat_x402_payment.PaidAPITool
+        config:
+          spending_policy:
+            max_per_transaction_usd: 1.00
+            max_daily_usd: 10.00
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+import httpx
+from langchain_core.tools import tool
+
+from nat_x402_payment.spending_policy import SpendingPolicy
+from nat_x402_payment.x402 import PaymentRequirement, parse_402_response, sign_payment
+
+logger = logging.getLogger(__name__)
+
+# Module-level spending policy (configured at startup)
+_spending_policy = SpendingPolicy()
+_wallet_key: str | None = None
+_mock_mode: bool = False
+
+
+def configure(
+    max_per_transaction_usd: float = 1.00,
+    max_daily_usd: float = 10.00,
+    allowed_recipients: list[str] | None = None,
+    require_confirmation: bool = False,
+    mock: bool = False,
+) -> None:
+    """Configure the payment tool's spending policy and wallet.
+
+    Call this at startup before the agent loop begins.
+    """
+    global _spending_policy, _wallet_key, _mock_mode
+
+    _spending_policy = SpendingPolicy(
+        max_per_transaction_usd=max_per_transaction_usd,
+        max_daily_usd=max_daily_usd,
+        allowed_recipients=set(allowed_recipients or []),
+        require_confirmation=require_confirmation,
+    )
+
+    _wallet_key = os.environ.get("AGENT_WALLET_PRIVATE_KEY")
+    _mock_mode = mock
+
+    if not _wallet_key and not mock:
+        logger.warning(
+            "AGENT_WALLET_PRIVATE_KEY not set. Payment tool will fail on real 402 responses. "
+            "Set mock=True for testing without a wallet."
+        )
+
+    logger.info(
+        "Payment tool configured: max_tx=$%.2f, max_daily=$%.2f, mock=%s",
+        max_per_transaction_usd,
+        max_daily_usd,
+        mock,
+    )
+
+
+@tool
+def paid_api_request(url: str, method: str = "GET") -> str:
+    """Make an HTTP request to a paid API, automatically handling x402 payment flows.
+
+    If the API returns HTTP 402, this tool evaluates the cost against the
+    spending policy, signs a payment proof, and retries the request.
+
+    Args:
+        url: The API endpoint URL to call.
+        method: HTTP method (GET, POST). Defaults to GET.
+
+    Returns:
+        The API response content, prefixed with payment status if a payment was made.
+    """
+    headers = {"User-Agent": "NeMo-Agent-Toolkit/1.0"}
+
+    with httpx.Client(timeout=30.0) as client:
+        # Initial request
+        response = client.request(method, url, headers=headers)
+
+        # If not 402, return directly
+        if response.status_code != 402:
+            return f"[HTTP {response.status_code}] {response.text}"
+
+        # Parse x402 payment requirement
+        requirement = parse_402_response(
+            dict(response.headers), response.content
+        )
+
+        if requirement is None:
+            return (
+                "[PAYMENT ERROR] Received 402 but could not parse x402 payment "
+                "requirements from the response. The API may not support x402."
+            )
+
+        # Check spending policy BEFORE signing
+        allowed, reason = _spending_policy.check(
+            requirement.amount_usd, requirement.recipient
+        )
+
+        if not allowed:
+            return (
+                f"[PAYMENT DENIED] {reason}. "
+                f"The API requires ${requirement.amount_usd:.4f} "
+                f"for: {requirement.description}"
+            )
+
+        if _spending_policy.require_confirmation:
+            return (
+                f"[PAYMENT CONFIRMATION REQUIRED] The API requests "
+                f"${requirement.amount_usd:.4f} for: {requirement.description}. "
+                f"Recipient: {requirement.recipient}. "
+                f"Please confirm to proceed."
+            )
+
+        # Sign the payment
+        if _mock_mode:
+            payment_proof = "mock_payment_proof_for_testing"
+            tx_hash = "0x" + "mock" * 16
+        else:
+            if not _wallet_key:
+                return "[PAYMENT ERROR] No wallet key configured. Cannot sign payment."
+
+            payment_proof = sign_payment(requirement, _wallet_key)
+            tx_hash = "0x" + payment_proof[:64]  # Simplified; real impl tracks on-chain
+
+        # Retry with payment proof
+        headers["X-Payment"] = payment_proof
+        headers["X-Payment-Token"] = requirement.token
+        headers["X-Payment-Network"] = requirement.network
+
+        response = client.request(method, url, headers=headers)
+
+        # Record the payment
+        _spending_policy.record_payment(
+            requirement.amount_usd, requirement.recipient, tx_hash
+        )
+
+        return (
+            f"[PAID ${requirement.amount_usd:.4f} — {requirement.description}] "
+            f"{response.text}"
+        )
+
+
+# Export for NeMo Agent Toolkit tool registration
+PaidAPITool = paid_api_request

--- a/examples/x402_payment_tool/src/nat_x402_payment/register.py
+++ b/examples/x402_payment_tool/src/nat_x402_payment/register.py
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Register the x402 payment tool with NeMo Agent Toolkit."""
+
+from nat_x402_payment.payment_tool import X402PaymentTool  # noqa: F401

--- a/examples/x402_payment_tool/src/nat_x402_payment/spending_policy.py
+++ b/examples/x402_payment_tool/src/nat_x402_payment/spending_policy.py
@@ -1,0 +1,116 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Spending policy enforcement for agent payments.
+
+The spending policy is evaluated BEFORE any payment is signed.
+This ensures the agent cannot exceed configured limits even if
+the LLM generates instructions to do so.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass, field
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SpendingPolicy:
+    """Configurable spending limits for agent payments.
+
+    Attributes:
+        max_per_transaction_usd: Maximum amount for a single payment.
+        max_daily_usd: Maximum total spend in a rolling 24-hour window.
+        allowed_recipients: Set of addresses the agent is allowed to pay.
+            If empty, all recipients are allowed.
+        require_confirmation: If True, the tool returns a confirmation
+            request instead of paying automatically.
+    """
+
+    max_per_transaction_usd: float = 1.00
+    max_daily_usd: float = 10.00
+    allowed_recipients: set[str] = field(default_factory=set)
+    require_confirmation: bool = False
+
+    # Internal tracking
+    _daily_spend: float = field(default=0.0, repr=False)
+    _daily_reset_time: float = field(default=0.0, repr=False)
+    _transaction_log: list[dict] = field(default_factory=list, repr=False)
+
+    def check(self, amount_usd: float, recipient: str) -> tuple[bool, str]:
+        """Evaluate whether a payment is allowed under the current policy.
+
+        Args:
+            amount_usd: Payment amount in USD.
+            recipient: Recipient address.
+
+        Returns:
+            Tuple of (allowed: bool, reason: str).
+        """
+        # Reset daily counter if 24h have passed
+        now = time.time()
+        if now - self._daily_reset_time > 86400:
+            self._daily_spend = 0.0
+            self._daily_reset_time = now
+
+        # Check per-transaction limit
+        if amount_usd > self.max_per_transaction_usd:
+            reason = (
+                f"Amount ${amount_usd:.2f} exceeds per-transaction limit "
+                f"of ${self.max_per_transaction_usd:.2f}"
+            )
+            logger.warning("Payment DENIED: %s", reason)
+            return False, reason
+
+        # Check daily limit
+        if self._daily_spend + amount_usd > self.max_daily_usd:
+            reason = (
+                f"Amount ${amount_usd:.2f} would exceed daily limit "
+                f"of ${self.max_daily_usd:.2f} "
+                f"(spent today: ${self._daily_spend:.2f})"
+            )
+            logger.warning("Payment DENIED: %s", reason)
+            return False, reason
+
+        # Check recipient allowlist
+        if self.allowed_recipients and recipient not in self.allowed_recipients:
+            reason = f"Recipient {recipient} is not in the allowed list"
+            logger.warning("Payment DENIED: %s", reason)
+            return False, reason
+
+        return True, "Payment approved"
+
+    def record_payment(self, amount_usd: float, recipient: str, tx_hash: str) -> None:
+        """Record a completed payment for audit and daily tracking."""
+        self._daily_spend += amount_usd
+        self._transaction_log.append(
+            {
+                "amount_usd": amount_usd,
+                "recipient": recipient,
+                "tx_hash": tx_hash,
+                "timestamp": time.time(),
+            }
+        )
+        logger.info(
+            "Payment recorded: $%.2f to %s (tx: %s) — daily total: $%.2f / $%.2f",
+            amount_usd,
+            recipient,
+            tx_hash,
+            self._daily_spend,
+            self.max_daily_usd,
+        )

--- a/examples/x402_payment_tool/src/nat_x402_payment/wallet.py
+++ b/examples/x402_payment_tool/src/nat_x402_payment/wallet.py
@@ -1,0 +1,213 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Wallet signing abstraction for x402 payments.
+
+Supports two modes:
+1. Inline signing (development) — private key in env var
+2. Remote signer (production) — signing key in a separate process
+
+The agent process NEVER has direct access to the private key in production.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from abc import ABC, abstractmethod
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+class WalletSigner(ABC):
+    """Abstract base class for wallet signing operations."""
+
+    @abstractmethod
+    def sign_payment(
+        self,
+        amount: int,
+        recipient: str,
+        asset: str,
+        network: str,
+    ) -> dict[str, Any]:
+        """
+        Sign an x402 payment.
+
+        Args:
+            amount: Payment amount in smallest unit (e.g., USDC uses 6 decimals)
+            recipient: Payment recipient address
+            asset: Token contract address
+            network: Target network (e.g., "base")
+
+        Returns:
+            Dict with "header" (x402 payment header), "tx_hash", and optionally "token"
+        """
+        ...
+
+    @abstractmethod
+    def get_address(self) -> str:
+        """Return the wallet's public address."""
+        ...
+
+    @abstractmethod
+    def get_balance(self, asset: str = "", network: str = "base") -> float:
+        """Return the wallet's balance for the given asset."""
+        ...
+
+
+class InlineWalletSigner(WalletSigner):
+    """
+    Development-only signer that uses a private key from an environment variable.
+
+    WARNING: This mode stores the private key in the same process as the agent.
+    Use RemoteWalletSigner for production deployments.
+    """
+
+    def __init__(self, private_key: str | None = None):
+        self._private_key = private_key or os.getenv("WALLET_PRIVATE_KEY", "")
+        if not self._private_key:
+            raise ValueError(
+                "WALLET_PRIVATE_KEY not set. For production, use WALLET_SIGNER_URL instead."
+            )
+
+        try:
+            from eth_account import Account
+
+            self._account = Account.from_key(self._private_key)
+            logger.info("Inline wallet initialized: %s", self._account.address)
+        except ImportError:
+            raise ImportError("eth-account is required for inline signing: pip install eth-account")
+
+    def get_address(self) -> str:
+        return self._account.address
+
+    def get_balance(self, asset: str = "", network: str = "base") -> float:
+        # Simplified — in production, query the chain
+        logger.warning("Balance check not implemented for inline signer; returning 0")
+        return 0.0
+
+    def sign_payment(
+        self,
+        amount: int,
+        recipient: str,
+        asset: str,
+        network: str,
+    ) -> dict[str, Any]:
+        """Sign an x402 payment using the local private key."""
+        from eth_account.messages import encode_defunct
+
+        # Construct the x402 payment message
+        message_data = {
+            "scheme": "exact",
+            "network": network,
+            "amount": str(amount),
+            "asset": asset,
+            "payTo": recipient,
+            "payer": self._account.address,
+        }
+
+        # Sign the message
+        message = encode_defunct(text=json.dumps(message_data, sort_keys=True))
+        signed = self._account.sign_message(message)
+
+        return {
+            "header": json.dumps(
+                {
+                    **message_data,
+                    "signature": signed.signature.hex(),
+                }
+            ),
+            "tx_hash": signed.signature.hex()[:16],  # Shortened for logging
+            "token": "",
+        }
+
+
+class RemoteWalletSigner(WalletSigner):
+    """
+    Production signer that delegates to a separate signing process.
+
+    The signing key never enters the agent's process memory.
+    The signer process runs on a separate port and only accepts
+    pre-validated payment requests.
+    """
+
+    def __init__(self, signer_url: str | None = None):
+        self._signer_url = signer_url or os.getenv("WALLET_SIGNER_URL", "")
+        if not self._signer_url:
+            raise ValueError("WALLET_SIGNER_URL not set")
+        logger.info("Remote wallet signer: %s", self._signer_url)
+
+    def get_address(self) -> str:
+        with httpx.Client(timeout=10.0) as client:
+            resp = client.get(f"{self._signer_url}/address")
+            resp.raise_for_status()
+            return resp.json()["address"]
+
+    def get_balance(self, asset: str = "", network: str = "base") -> float:
+        with httpx.Client(timeout=10.0) as client:
+            resp = client.get(
+                f"{self._signer_url}/balance",
+                params={"asset": asset, "network": network},
+            )
+            resp.raise_for_status()
+            return resp.json()["balance"]
+
+    def sign_payment(
+        self,
+        amount: int,
+        recipient: str,
+        asset: str,
+        network: str,
+    ) -> dict[str, Any]:
+        """Request the remote signer to sign an x402 payment."""
+        with httpx.Client(timeout=30.0) as client:
+            resp = client.post(
+                f"{self._signer_url}/sign",
+                json={
+                    "amount": str(amount),
+                    "recipient": recipient,
+                    "asset": asset,
+                    "network": network,
+                },
+            )
+            resp.raise_for_status()
+            return resp.json()
+
+
+def create_wallet_signer() -> WalletSigner:
+    """
+    Factory function that creates the appropriate signer based on environment.
+
+    Priority:
+    1. WALLET_SIGNER_URL → RemoteWalletSigner (production)
+    2. WALLET_PRIVATE_KEY → InlineWalletSigner (development)
+    """
+    signer_url = os.getenv("WALLET_SIGNER_URL", "")
+    if signer_url:
+        return RemoteWalletSigner(signer_url)
+
+    private_key = os.getenv("WALLET_PRIVATE_KEY", "")
+    if private_key:
+        return InlineWalletSigner(private_key)
+
+    raise ValueError(
+        "No wallet signer configured. Set WALLET_SIGNER_URL (production) "
+        "or WALLET_PRIVATE_KEY (development)."
+    )

--- a/examples/x402_payment_tool/src/nat_x402_payment/x402.py
+++ b/examples/x402_payment_tool/src/nat_x402_payment/x402.py
@@ -1,0 +1,145 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""x402 protocol helpers for parsing 402 responses and constructing payment proofs.
+
+The x402 protocol (https://github.com/coinbase/x402) uses HTTP 402 responses
+to communicate payment requirements. The server includes payment details in
+the response headers, and the client attaches a signed payment proof to the
+retry request.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class PaymentRequirement:
+    """Parsed payment requirement from a 402 response.
+
+    Attributes:
+        amount: Payment amount in the token's smallest unit (e.g., USDC has 6 decimals).
+        amount_usd: Payment amount in USD (derived from amount and token).
+        recipient: Address to pay.
+        token: Token contract address (e.g., USDC on Base).
+        network: Chain identifier (e.g., "base").
+        description: Human-readable description of what is being purchased.
+        nonce: Unique nonce to prevent replay attacks.
+        expires_at: Unix timestamp after which the payment requirement expires.
+    """
+
+    amount: int
+    amount_usd: float
+    recipient: str
+    token: str
+    network: str
+    description: str
+    nonce: str
+    expires_at: int
+
+
+def parse_402_response(headers: dict[str, str], body: bytes | str) -> PaymentRequirement | None:
+    """Extract payment requirements from an HTTP 402 response.
+
+    The x402 protocol encodes payment requirements in the response body as JSON.
+    See: https://github.com/coinbase/x402/blob/main/README.md
+
+    Args:
+        headers: Response headers.
+        body: Response body (JSON).
+
+    Returns:
+        PaymentRequirement if valid x402 response, None otherwise.
+    """
+    try:
+        if isinstance(body, bytes):
+            body = body.decode("utf-8")
+        data = json.loads(body)
+
+        # x402 response format
+        payment_info = data.get("payment", data)
+        amount = int(payment_info.get("amount", 0))
+
+        # USDC has 6 decimals
+        token = payment_info.get("token", "")
+        amount_usd = amount / 1_000_000 if "usdc" in token.lower() or amount > 0 else 0
+
+        return PaymentRequirement(
+            amount=amount,
+            amount_usd=amount_usd,
+            recipient=payment_info.get("recipient", ""),
+            token=token,
+            network=payment_info.get("network", "base"),
+            description=payment_info.get("description", "Paid API access"),
+            nonce=payment_info.get("nonce", ""),
+            expires_at=int(payment_info.get("expires_at", time.time() + 300)),
+        )
+    except (json.JSONDecodeError, KeyError, ValueError) as exc:
+        logger.warning("Failed to parse 402 response as x402: %s", exc)
+        return None
+
+
+def sign_payment(
+    requirement: PaymentRequirement,
+    private_key: str,
+) -> str:
+    """Sign a payment proof for the given requirement.
+
+    SECURITY NOTE: This function is the ONLY place the private key is used.
+    It runs outside the agent's context window. The returned payment proof
+    is a signed authorization that can only be used for this specific payment.
+
+    Args:
+        requirement: The payment requirement to fulfill.
+        private_key: Hex-encoded private key for signing.
+
+    Returns:
+        Hex-encoded signed payment proof.
+    """
+    from eth_account import Account
+    from eth_account.messages import encode_defunct
+
+    # Construct the payment message
+    message = json.dumps(
+        {
+            "amount": str(requirement.amount),
+            "recipient": requirement.recipient,
+            "token": requirement.token,
+            "nonce": requirement.nonce,
+            "network": requirement.network,
+            "expires_at": requirement.expires_at,
+        },
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+    # Sign with the agent's wallet key
+    signable = encode_defunct(text=message)
+    signed = Account.sign_message(signable, private_key=private_key)
+
+    logger.info(
+        "Payment signed: $%.4f to %s (nonce: %s)",
+        requirement.amount_usd,
+        requirement.recipient[:10] + "...",
+        requirement.nonce[:8] + "...",
+    )
+
+    return signed.signature.hex()


### PR DESCRIPTION
## Summary

Adds a community-contributed example demonstrating a payment-enabled tool for NeMo Agent Toolkit that handles [x402](https://github.com/coinbase/x402) (HTTP 402) payment negotiation within a ReAct agent loop.

**Related issue:** NVIDIA/NeMo-Agent-Toolkit#1806

## What This Example Shows

When an AI agent calls a paid API and receives an HTTP 402 response, this tool:
1. Parses the x402 payment requirements
2. Checks the agent's spending policy (per-tx cap, daily limit, recipient allowlist)
3. Signs the payment (wallet key isolated from agent process)
4. Retries the request with payment proof
5. Returns the data to the agent

## Why Payment Tools Are Different From Regular Tools

(Per discussion in NVIDIA/NeMo-Agent-Toolkit#1806)

- **Irreversibility:** A bad API call is a wasted retry. A bad payment is lost funds.
- **Key isolation:** API keys rotate; private keys don't. Signing must live outside the MCP trust boundary.
- **Budget enforcement:** Spending policy is enforced at the wallet layer, not the LLM layer — hallucinations cannot exceed limits.

## Files

| File | Purpose |
|------|---------|
| `payment_tool.py` | Main tool with 402 detection, policy check, payment, retry |
| `wallet.py` | Wallet signing abstraction (inline dev / remote prod) |
| `spending_policy.py` | Configurable spending limits and allowlists |
| `x402.py` | x402 protocol helpers (parse 402 responses, construct proofs) |
| `mock_x402_server.py` | Mock paid API for testing without real transactions |
| `register.py` | NeMo Agent Toolkit component registration |

## Testing

```bash
cd examples/x402_payment_tool
pip install -e .
python scripts/mock_x402_server.py &  # Start mock paid API
# Run agent with the payment tool
```

## References

- [x402 Protocol (Coinbase, 5.6k stars)](https://github.com/coinbase/x402)
- [agent-wallet-sdk](https://github.com/up2itnow0822/agent-wallet-sdk) — Non-custodial agent wallets
- [agentpay-mcp](https://github.com/up2itnow0822/agentpay-mcp) — MCP payment server