### PR TITLE
Add Unstructured Transform MCP example

### DIFF
--- a/ci/vale/styles/config/vocabularies/nemo-agent-toolkit-examples/accept.txt
+++ b/ci/vale/styles/config/vocabularies/nemo-agent-toolkit-examples/accept.txt
@@ -138,6 +138,7 @@ seaborn
 [Ss]ubgraph(s?)
 [Ss]ubpackage(s?)
 [Ss]ubword(s?)
+[Ss]treamable
 [Ss]uperset(s?)
 Tavily
 [Tt]eardown
@@ -148,6 +149,7 @@ triages
 [Uu]nencrypted
 [Uu]nittest(s?)
 [Uu]nprocessable
+[Uu]ntrusted
 [Uu]ploader
 [Uu]psert
 uv

--- a/examples/unstructured_transform_mcp/README.md
+++ b/examples/unstructured_transform_mcp/README.md
@@ -1,0 +1,223 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Document Transformation with the Unstructured Transform MCP Server
+
+**Complexity:** Intermediate
+
+This example demonstrates how the NVIDIA NeMo Agent Toolkit connects to a third-party remote MCP server that is protected by static bearer-token authentication: the hosted [Unstructured Transform](https://transform.unstructured.io/get-started) service, which converts documents (PDF, DOCX, PPTX, XLSX, HTML, images, and 40+ other formats) into clean Markdown that agents can reason over.
+
+It also demonstrates a useful composition pattern: the remote MCP server exposes an asynchronous, multi-step protocol, and this example wraps that protocol in a single deterministic custom function so the agent only needs one reliable tool call.
+
+This example is hosted in the examples repository because it requires an Unstructured API key and depends on an external MCP server whose data, schema, availability, and responses are not controlled by the toolkit. It is a reference integration, and it targets NeMo Agent Toolkit 1.8.
+
+## Key Features
+
+- **Bearer-token MCP authentication:** Uses the `api_key` authentication provider with `auth_scheme: Bearer` to authenticate against a remote MCP server with a static API key supplied through an environment variable. The other MCP examples in the NeMo Agent Toolkit cover unauthenticated servers and OAuth2 flows; this example covers the common "API key in a header" case.
+- **Remote MCP client over streamable HTTP:** Declares the Transform server as an `mcp_client` function group using the `streamable-http` transport.
+- **Deterministic composition of MCP tools:** A custom function (`transform_document`) resolves the four Transform MCP tools from the function group and orchestrates the upload, transform, poll, and download flow in plain Python, exposing one dependable tool to the ReAct agent.
+- **Document parsing for agents:** Turns binary documents into Markdown the LLM can summarize, query, and extract from.
+
+## How It Works
+
+The Unstructured Transform MCP server exposes an asynchronous job protocol as four tools:
+
+1. `request_file_upload_url`: Returns a pre-signed upload URL and a file reference for a local file.
+2. `transform_files`: Starts a transform job for one or more file references (or public HTTP(S) URLs) and returns a job ID.
+3. `check_transform_status`: Reports whether the job is `SCHEDULED`, `IN_PROGRESS`, or `COMPLETED` (any other state means the job failed, and the function reports it as an error).
+4. `get_transform_results`: Returns a pre-signed download URL for the Markdown output of each transformed file.
+
+Two steps of the protocol are plain HTTP transfers rather than MCP calls: uploading the raw document bytes to the pre-signed upload URL and downloading the Markdown from the pre-signed download URL. An agent cannot perform those byte transfers with MCP tools alone, and letting an LLM drive the polling loop is slow and unreliable. The `transform_document` function in `src/nat_unstructured_transform_mcp/register.py` therefore performs the whole sequence deterministically:
+
+```text
+agent -> transform_document(source)
+           |-- request_file_upload_url (MCP)      # local files only
+           |-- PUT raw bytes to upload URL        # plain HTTP, no bearer token
+           |-- transform_files (MCP)
+           |-- check_transform_status (MCP)       # polled until COMPLETED
+           |-- get_transform_results (MCP)
+           `-- GET Markdown from download URL     # plain HTTP, no bearer token
+```
+
+The function accepts either a local file path or a public HTTP(S) URL (public URLs are passed directly to `transform_files`, skipping the upload). Transforms take from a few seconds up to several minutes depending on page count, and the maximum file size is 50 MB. Each `transform_document` call processes a single document, and the example always requests the default Markdown output; the Transform service also supports element JSON, HTML, and plain-text output, which would require extending `transform_document`.
+
+> [!IMPORTANT]
+> Trust boundary: for a local path, `transform_document` reads that file and uploads its contents to the hosted Transform service. Because the path comes from the agent, a crafted prompt could point it at a sensitive file (for example a private key or a credentials file) and cause that file to leave the host. Run this example with documents and prompts you trust, and if you adapt it for untrusted input, restrict the accepted paths to a designated directory.
+
+## Prerequisites
+
+1. **Unstructured Transform API key:** Sign up and create a key at [transform.unstructured.io/get-started](https://transform.unstructured.io/get-started).
+2. **NVIDIA API key:** The workflow uses an NVIDIA NIM hosted model. Get your key from the [NVIDIA API Catalog](https://build.nvidia.com/).
+3. **NeMo Agent Toolkit development environment:** Clone this repository and create the development environment described in the root [README](../../README.md). Installing this example (below) pulls in the toolkit with MCP and LangChain support from PyPI.
+
+## Installation and Setup
+
+### Install this Workflow
+
+From the root of the repository, run:
+
+```bash
+uv pip install -e examples/unstructured_transform_mcp
+```
+
+### Set Up API Keys
+
+```bash
+export UNSTRUCTURED_API_KEY=<YOUR_UNSTRUCTURED_API_KEY>
+export NVIDIA_API_KEY=<YOUR_NVIDIA_API_KEY>
+```
+
+## Run the Workflow
+
+Ask the agent to transform a document and answer a question about it. The input can be a public HTTPS URL:
+
+```bash
+nat run --config_file examples/unstructured_transform_mcp/configs/config.yml \
+  --input "Transform https://arxiv.org/pdf/1706.03762 to Markdown and list the section headings."
+```
+
+Or a local file:
+
+<!-- path-check-skip-begin -->
+```bash
+nat run --config_file examples/unstructured_transform_mcp/configs/config.yml \
+  --input "Transform the document at /path/to/your/document.pdf and summarize it in three bullet points."
+```
+<!-- path-check-skip-end -->
+
+**Expected Workflow Output**
+
+The transform takes roughly one to three minutes for this 15-page paper, after which the agent answers from the returned Markdown:
+
+```text
+Workflow Result:
+The section headings of the transformed document are:
+- # Attention Is All You Need
+- # 2 Background
+- # 3 Model Architecture
+- # 3.1 Encoder and Decoder Stacks
+- # 3.2 Attention
+- # 3.2.1 Scaled Dot-Product Attention
+- # 3.2.2 Multi-Head Attention
+- # 3.3 Position-wise Feed-Forward Networks
+- # 3.4 Embeddings and Softmax
+- # 3.5 Positional Encoding
+- # 4 Why Self-Attention
+- # 5 Training
+- # 5.1 Training Data and Batching
+- # 5.2 Hardware and Schedule
+- # 5.3 Optimizer
+- # 5.4 Regularization
+- # 6 Results
+- # 6.1 Machine Translation
+- # 6.2 Model Variations
+- # 6.3 English Constituency Parsing
+- # 7 Conclusion
+- # References
+```
+
+## Configuration Details
+
+The complete configuration is in `configs/config.yml`. The MCP client and authentication sections are the interesting parts:
+
+```yaml
+function_groups:
+  unstructured_transform:
+    _type: mcp_client
+    server:
+      transport: streamable-http
+      url: https://mcp.transform.unstructured.io
+      auth_provider: unstructured_auth
+    include:
+      - request_file_upload_url
+      - transform_files
+      - check_transform_status
+      - get_transform_results
+
+authentication:
+  unstructured_auth:
+    _type: api_key
+    raw_key: ${UNSTRUCTURED_API_KEY}
+    auth_scheme: Bearer
+```
+
+- The `api_key` authentication provider attaches `Authorization: Bearer <UNSTRUCTURED_API_KEY>` to every request the MCP client makes, including the initial handshake.
+- `${UNSTRUCTURED_API_KEY}` is interpolated from the environment when the configuration is loaded. See [workflow configuration](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/main/docs/source/build-workflows/workflow-configuration.md) for the interpolation syntax.
+- The `include` list documents the four tools the example depends on and fails fast if the server stops exposing any of them.
+- The `transform_document` function references the function group through its `mcp_group` setting, so the group does not need to appear in the workflow `tool_names` and the agent never sees the low-level tools.
+
+### Alternative: Custom Headers
+
+If you prefer not to define an authentication provider, the MCP client can also send a static header directly. This variant sends the same header but does not retry on authentication failures:
+
+```yaml
+function_groups:
+  unstructured_transform:
+    _type: mcp_client
+    server:
+      transport: streamable-http
+      url: https://mcp.transform.unstructured.io
+      custom_headers:
+        Authorization: "Bearer ${UNSTRUCTURED_API_KEY}"
+    include:
+      - request_file_upload_url
+      - transform_files
+      - check_transform_status
+      - get_transform_results
+```
+
+Keep the `include` list in this variant as well; it provides the same fail-fast contract check described above.
+
+### Tuning
+
+The `transform_document` function accepts a few settings in the `functions` section of the configuration:
+
+| Setting | Default | Purpose |
+|---|---|---|
+| `poll_interval_seconds` | `5.0` | Delay between job status checks. |
+| `transform_timeout_seconds` | `900.0` | Maximum time to wait for a transform job. Raise this for very large documents. |
+| `http_timeout_seconds` | `120.0` | Timeout for the raw upload and download requests. |
+| `max_file_size_bytes` | `52428800` | Maximum document size accepted by the Transform service (50 MB at the time of writing). |
+| `max_output_characters` | `50000` | Truncates the returned Markdown to protect the context window of the agent; a short truncation notice is appended. |
+
+## Testing
+
+Unit tests mock the MCP tools and the HTTP transfers, so they run without network access or credentials:
+
+```bash
+pytest examples/unstructured_transform_mcp/tests
+```
+
+Integration tests run against the live Transform service and are skipped unless `UNSTRUCTURED_API_KEY` is set (the full workflow test also requires `NVIDIA_API_KEY`):
+
+```bash
+pytest --run_integration --run_slow examples/unstructured_transform_mcp/tests
+```
+
+## Troubleshooting
+
+- **Authentication errors during startup:** A missing `UNSTRUCTURED_API_KEY` fails configuration validation immediately with a `raw_key` error, because the environment variable interpolates to an empty string. An invalid key fails the MCP handshake when the workflow is built. In both cases, verify the variable is exported in the shell that runs `nat run`.
+- **Transform timed out:** Large documents can take several minutes. Raise `transform_timeout_seconds` in the `transform_document` function configuration.
+- **Transform job ended in an unexpected state:** The document could not be processed on the server (for example, a corrupt or unsupported file). The error includes the status payload returned by the service.
+- **File too large:** The Transform service accepts files up to 50 MB.
+- **Document not found:** The agent passes the file path verbatim, so use an absolute path in the prompt.
+
+## Related Examples and Documentation
+
+- [`kaggle_mcp`](../kaggle_mcp/README.md): Another remote MCP server reached over `streamable-http` with bearer-token authentication.
+- [MCP client documentation](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/main/docs/source/build-workflows/mcp-client.md): All `mcp_client` configuration options.
+- [API authentication documentation](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/main/docs/source/components/auth/api-authentication.md): Details of the `api_key` authentication provider.

--- a/examples/unstructured_transform_mcp/configs
+++ b/examples/unstructured_transform_mcp/configs
@@ -1,0 +1,1 @@
+src/nat_unstructured_transform_mcp/configs

--- a/examples/unstructured_transform_mcp/pyproject.toml
+++ b/examples/unstructured_transform_mcp/pyproject.toml
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[build-system]
+build-backend = "setuptools.build_meta"
+requires = ["setuptools >= 64", "setuptools-scm>=8"]
+
+[tool.setuptools_scm]
+git_describe_command = "git describe --long --first-parent"
+root = "../.."
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[project]
+name = "nat_unstructured_transform_mcp"
+dynamic = ["version"]
+requires-python = ">=3.11,<3.14"
+description = "Demonstrates NeMo Agent Toolkit connecting to the bearer-token protected Unstructured Transform MCP server"
+dependencies = [
+  "nvidia-nat[langchain,mcp,test]>=1.8.0,<1.9.0",
+  "httpx~=0.27",
+]
+keywords = ["ai", "mcp", "protocol", "agents", "documents"]
+classifiers = ["Programming Language :: Python"]
+
+[project.entry-points.'nat.components']
+nat_unstructured_transform_mcp = "nat_unstructured_transform_mcp.register"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"

--- a/examples/unstructured_transform_mcp/src/nat_unstructured_transform_mcp/__init__.py
+++ b/examples/unstructured_transform_mcp/src/nat_unstructured_transform_mcp/__init__.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/examples/unstructured_transform_mcp/src/nat_unstructured_transform_mcp/configs/config.yml
+++ b/examples/unstructured_transform_mcp/src/nat_unstructured_transform_mcp/configs/config.yml
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+functions:
+  # Deterministic wrapper around the four Transform MCP tools. The agent sees this one
+  # tool instead of orchestrating the multi-step upload, transform, poll, and download protocol.
+  transform_document:
+    _type: transform_document
+    mcp_group: unstructured_transform
+    poll_interval_seconds: 5.0
+    transform_timeout_seconds: 900.0
+
+function_groups:
+  unstructured_transform:
+    _type: mcp_client
+    server:
+      transport: streamable-http
+      # The Unstructured Transform MCP server is served at the root path.
+      url: https://mcp.transform.unstructured.io
+      auth_provider: unstructured_auth
+    # The four tools that make up the asynchronous transform protocol.
+    include:
+      - request_file_upload_url
+      - transform_files
+      - check_transform_status
+      - get_transform_results
+
+authentication:
+  unstructured_auth:
+    # Static bearer-token authentication: every request to the MCP server carries an
+    # "Authorization: Bearer <UNSTRUCTURED_API_KEY>" header.
+    _type: api_key
+    raw_key: ${UNSTRUCTURED_API_KEY}
+    auth_scheme: Bearer
+
+llms:
+  nim_llm:
+    _type: nim
+    model_name: nvidia/nemotron-3-nano-30b-a3b
+    temperature: 0.0
+    max_tokens: 2048
+    chat_template_kwargs:
+      enable_thinking: false
+
+workflow:
+  _type: react_agent
+  tool_names:
+    - transform_document
+  llm_name: nim_llm
+  verbose: true
+  retry_parsing_errors: true
+  max_retries: 3

--- a/examples/unstructured_transform_mcp/src/nat_unstructured_transform_mcp/register.py
+++ b/examples/unstructured_transform_mcp/src/nat_unstructured_transform_mcp/register.py
@@ -1,0 +1,386 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Register the ``transform_document`` function.
+
+The Unstructured Transform MCP server exposes an asynchronous, multi-step protocol
+(request an upload URL, upload the raw bytes over plain HTTP, start a transform job,
+poll for completion, download the result). This module composes those MCP tools into a
+single deterministic function so the agent only needs one reliable tool call.
+"""
+
+import asyncio
+import json
+import logging
+import mimetypes
+import typing
+from pathlib import Path
+
+import httpx
+from pydantic import BaseModel
+from pydantic import Field
+
+from nat.builder.builder import Builder
+from nat.builder.function import Function
+from nat.builder.function import FunctionGroup
+from nat.builder.function_info import FunctionInfo
+from nat.cli.register_workflow import register_function
+from nat.data_models.component_ref import FunctionGroupRef
+from nat.data_models.function import FunctionBaseConfig
+
+logger = logging.getLogger(__name__)
+
+# Maximum file size accepted by the Unstructured Transform service (50 MB).
+MAX_FILE_SIZE_BYTES = 52_428_800
+
+# Job states reported by the check_transform_status MCP tool which mean "keep waiting".
+_PENDING_JOB_STATES = frozenset({"SCHEDULED", "IN_PROGRESS"})
+_COMPLETED_JOB_STATE = "COMPLETED"
+
+# The MCP client converts transport-level failures into plain-text tool output; the
+# idempotent polling calls tolerate this many consecutive such failures before giving up.
+_MAX_CONSECUTIVE_POLL_FAILURES = 3
+
+
+class TransformDocumentConfig(FunctionBaseConfig, name="transform_document"):
+    """Configuration for the ``transform_document`` function."""
+
+    mcp_group: FunctionGroupRef = Field(
+        default=FunctionGroupRef("unstructured_transform"),
+        description="Reference to the mcp_client function group connected to the Unstructured Transform MCP server.")
+    poll_interval_seconds: float = Field(default=5.0, gt=0, description="Delay between transform job status checks.")
+    transform_timeout_seconds: float = Field(
+        default=900.0,
+        gt=0,
+        description="Maximum time to wait for a transform job to complete. Large documents take longer.")
+    http_timeout_seconds: float = Field(
+        default=120.0, gt=0, description="Timeout for the plain HTTP file upload and result download requests.")
+    max_file_size_bytes: int = Field(
+        default=MAX_FILE_SIZE_BYTES,
+        gt=0,
+        description="Maximum document size accepted by the Transform service (50 MB at the time of writing).")
+    max_output_characters: int = Field(
+        default=50_000,
+        gt=0,
+        description="Truncate the returned Markdown body beyond this length to protect the context window of the "
+        "agent. A short truncation notice is appended to truncated output.")
+
+
+class TransformResult(BaseModel):
+    """Outcome of a single document transform."""
+
+    markdown: str
+    element_count: int
+    character_count: int
+    filename: str
+
+
+class TransformTools(typing.NamedTuple):
+    """The four Unstructured Transform MCP tools, resolved from the function group."""
+
+    request_file_upload_url: Function
+    transform_files: Function
+    check_transform_status: Function
+    get_transform_results: Function
+
+
+def resolve_tools(group_functions: dict[str, Function]) -> TransformTools:
+    """Look up the Transform MCP tools in a function group by their MCP tool names.
+
+    Function groups expose members as ``<group_instance>__<tool_name>``; the tool name is
+    recovered with the framework ``FunctionGroup.decompose`` helper.
+
+    Args:
+        group_functions: Accessible functions of the mcp_client function group.
+
+    Returns:
+        The resolved Transform MCP tools.
+
+    Raises:
+        ValueError: If a required tool is not present in the function group.
+    """
+    by_tool_name = {FunctionGroup.decompose(full_name)[1]: fn for full_name, fn in group_functions.items()}
+
+    missing = [name for name in TransformTools._fields if name not in by_tool_name]
+    if missing:
+        raise ValueError(f"Required MCP tools {missing} were not found in the function group. "
+                         f"Available tools: {sorted(by_tool_name)}")
+
+    return TransformTools(**{name: by_tool_name[name] for name in TransformTools._fields})
+
+
+class MCPToolError(RuntimeError):
+    """Raised when a Transform MCP tool returns an error payload."""
+
+    def __init__(self, tool_name: str, code: str, message: str):
+        self.code = code
+        super().__init__(f"The '{tool_name}' MCP tool returned an error ({code}): {message}")
+
+
+async def _invoke_tool(tool: Function, **tool_args: typing.Any) -> dict[str, typing.Any]:
+    """Invoke an MCP tool and parse its JSON text content into a dictionary."""
+    raw = await tool.ainvoke(tool.input_schema(**tool_args))
+    try:
+        payload = json.loads(raw)
+    except (json.JSONDecodeError, TypeError) as e:
+        raise RuntimeError(f"Expected a JSON payload from the '{tool.instance_name}' MCP tool but received: "
+                           f"{str(raw)[:300]!r}") from e
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"Expected a JSON object from the '{tool.instance_name}' MCP tool but received: "
+                           f"{str(raw)[:300]!r}")
+    error = payload.get("error")
+    if isinstance(error, dict):
+        raise MCPToolError(tool.instance_name, str(error.get("code", "unknown")), str(error.get("message", error)))
+    return payload
+
+
+def _require(payload: dict[str, typing.Any], key: str, tool_name: str) -> typing.Any:
+    """Return a required key from an MCP tool payload, or raise a descriptive error."""
+    try:
+        return payload[key]
+    except KeyError as e:
+        raise RuntimeError(f"The '{tool_name}' MCP tool response is missing the required '{key}' field: "
+                           f"{str(payload)[:300]!r}") from e
+
+
+def _check_http_response(response: httpx.Response, description: str) -> None:
+    """Raise a descriptive error for a failed HTTP transfer without leaking the pre-signed URL.
+
+    The query string of a pre-signed URL carries its signature, which is a credential. This
+    error message reaches logs and the agent, so it includes only the scheme, host, and path.
+    """
+    if response.status_code >= 400:
+        safe_url = response.request.url.copy_with(query=None, fragment=None)
+        raise RuntimeError(f"The {description} failed with HTTP {response.status_code} from {safe_url}")
+
+
+async def _upload_source(tools: TransformTools, http_client: httpx.AsyncClient, source: str,
+                         max_file_size_bytes: int) -> str:
+    """Return a file reference for the document, uploading local files first.
+
+    Public HTTP or HTTPS URLs are passed through unchanged because the transform_files
+    MCP tool accepts them directly. Local files are uploaded to a pre-signed URL minted
+    by the request_file_upload_url MCP tool.
+    """
+    if source.startswith(("http://", "https://")):
+        return source
+
+    path = Path(source).expanduser()
+    # Filesystem access is offloaded to a worker thread so the reads (up to the size limit)
+    # do not block the event loop, per the async I/O guideline.
+    if not await asyncio.to_thread(path.is_file):
+        raise FileNotFoundError(f"Document not found: {source}")
+
+    size_bytes = (await asyncio.to_thread(path.stat)).st_size
+    if size_bytes > max_file_size_bytes:
+        raise ValueError(f"Document is {size_bytes} bytes which exceeds the "
+                         f"{max_file_size_bytes} byte limit of the Transform service.")
+
+    content_type = mimetypes.guess_type(path.name)[0] or "application/octet-stream"
+    upload = await _invoke_tool(tools.request_file_upload_url,
+                                filename=path.name,
+                                content_type=content_type,
+                                size_bytes=size_bytes)
+
+    # Upload the raw bytes to the pre-signed URL. This is a plain HTTP request, not an
+    # MCP call, and the pre-signed URL must not receive the bearer token.
+    file_bytes = await asyncio.to_thread(path.read_bytes)
+    response = await http_client.request(str(upload.get("method", "PUT")),
+                                         _require(upload, "upload_url", "request_file_upload_url"),
+                                         content=file_bytes,
+                                         headers=upload.get("headers") or {})
+    _check_http_response(response, "document upload")
+
+    return _require(upload, "file_ref", "request_file_upload_url")
+
+
+def _timeout_error(job_id: str, timeout_seconds: float) -> TimeoutError:
+    return TimeoutError(f"Transform job {job_id} did not complete within {timeout_seconds} seconds. "
+                        "Large documents can take several minutes; consider raising transform_timeout_seconds.")
+
+
+async def _wait_for_job(tools: TransformTools,
+                        job_id: str,
+                        poll_interval_seconds: float,
+                        deadline: float,
+                        timeout_seconds: float) -> None:
+    """Poll the transform job status until it completes, fails, or times out.
+
+    Transport-level blips (which the MCP client surfaces as plain-text tool output rather
+    than exceptions) are retried a few times so a momentary hiccup does not abandon a
+    long-running server-side job.
+    """
+    loop = asyncio.get_running_loop()
+    consecutive_failures = 0
+
+    while True:
+        try:
+            status_payload = await _invoke_tool(tools.check_transform_status, job_id=job_id)
+        except MCPToolError:
+            raise
+        except RuntimeError:
+            consecutive_failures += 1
+            if consecutive_failures >= _MAX_CONSECUTIVE_POLL_FAILURES or loop.time() >= deadline:
+                raise
+            logger.warning("Status check for transform job %s failed (%d consecutive); retrying",
+                           job_id,
+                           consecutive_failures)
+            await asyncio.sleep(poll_interval_seconds)
+            continue
+        consecutive_failures = 0
+
+        status = str(status_payload.get("status", "")).upper()
+
+        if status == _COMPLETED_JOB_STATE:
+            return
+        if status not in _PENDING_JOB_STATES:
+            raise RuntimeError(f"Transform job {job_id} ended in unexpected state '{status}': "
+                               f"{str(status_payload)[:300]!r}")
+        if loop.time() >= deadline:
+            raise _timeout_error(job_id, timeout_seconds)
+
+        logger.debug("Transform job %s is %s; polling again in %.1f seconds", job_id, status, poll_interval_seconds)
+        await asyncio.sleep(poll_interval_seconds)
+
+
+async def _fetch_results(tools: TransformTools,
+                         job_id: str,
+                         poll_interval_seconds: float,
+                         deadline: float,
+                         timeout_seconds: float) -> dict[str, typing.Any]:
+    """Fetch the transform results, tolerating the brief window after the job reports completion.
+
+    The status endpoint can report ``COMPLETED`` slightly before the results are
+    materialized, in which case get_transform_results returns a ``job_not_complete``
+    error. Retry within the overall transform deadline. Transport-level blips are retried
+    the same way as in the status loop.
+    """
+    loop = asyncio.get_running_loop()
+    consecutive_failures = 0
+
+    while True:
+        try:
+            return await _invoke_tool(tools.get_transform_results, job_id=job_id)
+        except MCPToolError as e:
+            if e.code != "job_not_complete":
+                raise
+            # The server reports job_not_complete as a JSON error envelope inside a
+            # successful (isError=false) tool result; this is the observed behavior of the
+            # brief status-vs-results consistency window and is safe to retry.
+            if loop.time() >= deadline:
+                raise _timeout_error(job_id, timeout_seconds) from e
+            consecutive_failures = 0
+        except RuntimeError:
+            consecutive_failures += 1
+            if consecutive_failures >= _MAX_CONSECUTIVE_POLL_FAILURES or loop.time() >= deadline:
+                raise
+            logger.warning("Results fetch for transform job %s failed (%d consecutive); retrying",
+                           job_id,
+                           consecutive_failures)
+
+        logger.debug("Transform job %s results are not ready yet; polling again in %.1f seconds",
+                     job_id,
+                     poll_interval_seconds)
+        await asyncio.sleep(poll_interval_seconds)
+
+
+async def transform_source(tools: TransformTools, config: TransformDocumentConfig, source: str) -> TransformResult:
+    """Run the full upload, transform, poll, and download flow for one document.
+
+    Args:
+        tools: The resolved Transform MCP tools.
+        config: The function configuration.
+        source: Local file path or public HTTP or HTTPS URL of the document.
+
+    Returns:
+        The transformed document as Markdown plus transform metadata.
+    """
+    async with httpx.AsyncClient(timeout=config.http_timeout_seconds) as http_client:
+        file_ref = await _upload_source(tools, http_client, source, config.max_file_size_bytes)
+
+        job = await _invoke_tool(tools.transform_files, file_refs=[file_ref])
+        job_id = _require(job, "job_id", "transform_files")
+        logger.info("Started transform job %s for '%s'", job_id, source)
+
+        # The status wait and the results fetch share one overall deadline.
+        deadline = asyncio.get_running_loop().time() + config.transform_timeout_seconds
+        await _wait_for_job(tools, job_id, config.poll_interval_seconds, deadline, config.transform_timeout_seconds)
+
+        results = await _fetch_results(tools,
+                                       job_id,
+                                       config.poll_interval_seconds,
+                                       deadline,
+                                       config.transform_timeout_seconds)
+        files = results.get("files")
+        if not isinstance(files, list) or not files:
+            raise RuntimeError(f"Transform job {job_id} completed but returned no files.")
+        first_file = files[0]
+        if not isinstance(first_file, dict):
+            raise RuntimeError(f"Transform job {job_id} returned an unexpected files entry: "
+                               f"{str(first_file)[:300]!r}")
+
+        # The download URL is pre-signed as well, so no bearer token is sent here either.
+        download = await http_client.get(_require(first_file, "download_url", "get_transform_results"))
+        _check_http_response(download, "result download")
+
+        return TransformResult(markdown=download.text,
+                               element_count=int(first_file.get("element_count") or 0),
+                               character_count=int(first_file.get("character_count") or len(download.text)),
+                               filename=str(first_file.get("filename") or Path(source).name))
+
+
+@register_function(config_type=TransformDocumentConfig)
+async def transform_document(config: TransformDocumentConfig, builder: Builder):
+    """Register the ``transform_document`` function.
+
+    Resolves the four Unstructured Transform MCP tools from the configured mcp_client
+    function group and exposes the whole flow to the agent as one tool.
+    """
+    group = await builder.get_function_group(config.mcp_group)
+    tools = resolve_tools(await group.get_accessible_functions())
+
+    async def _transform(source: str) -> str:
+        """Transform a document into Markdown.
+
+        Args:
+            source: Local file path or public HTTP or HTTPS URL of the document.
+
+        Returns:
+            The document content converted to Markdown, or an error description.
+        """
+        try:
+            result = await transform_source(tools, config, source)
+        except (OSError, ValueError, RuntimeError, TimeoutError, httpx.HTTPError, httpx.InvalidURL) as e:
+            logger.exception("Failed to transform '%s'", source)
+            return f"ERROR: failed to transform '{source}': {e}"
+
+        logger.info("Transformed '%s': %d elements, %d characters",
+                    result.filename,
+                    result.element_count,
+                    result.character_count)
+
+        markdown = result.markdown
+        if len(markdown) > config.max_output_characters:
+            markdown = (f"{markdown[:config.max_output_characters]}\n\n"
+                        f"[Output truncated at {config.max_output_characters} characters. The full document has "
+                        f"{result.character_count} characters.]")
+        return markdown
+
+    yield FunctionInfo.from_fn(
+        _transform,
+        description=("Convert a document (PDF, DOCX, PPTX, XLSX, HTML, images, and 40+ other formats) into "
+                     "clean Markdown using the Unstructured Transform service. The input must be either the path to "
+                     "a local file or a public HTTP or HTTPS URL of the document. Returns the extracted content as "
+                     "Markdown. Transformation is asynchronous on the server and can take from a few seconds up to "
+                     "several minutes depending on document size."))

--- a/examples/unstructured_transform_mcp/tests/test_transform_document.py
+++ b/examples/unstructured_transform_mcp/tests/test_transform_document.py
@@ -1,0 +1,581 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for the transform_document orchestration. No network access is required."""
+
+import json
+import typing
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import pytest
+from pydantic import BaseModel
+from pydantic import ConfigDict
+from pytest_httpserver import HTTPServer
+
+from nat_unstructured_transform_mcp.register import TransformDocumentConfig
+from nat_unstructured_transform_mcp.register import TransformTools
+from nat_unstructured_transform_mcp.register import resolve_tools
+from nat_unstructured_transform_mcp.register import transform_document
+from nat_unstructured_transform_mcp.register import transform_source
+
+_GROUP = "unstructured_transform"
+
+
+class _ToolArgs(BaseModel):
+    """Permissive input-schema stand-in that accepts any tool arguments."""
+    model_config = ConfigDict(extra="allow")
+
+
+class _FakeTool:
+    """Mimics an MCP tool exposed through a function group: JSON text in, JSON text out."""
+
+    def __init__(self, name: str, handler: typing.Callable[..., typing.Awaitable[str]]):
+        self.instance_name = f"{_GROUP}__{name}"
+        self.input_schema = _ToolArgs
+        self.calls: list[dict[str, typing.Any]] = []
+        self._handler = handler
+
+    async def ainvoke(self, value: _ToolArgs) -> str:
+        """Record the call arguments and return the handler's canned response."""
+        args = value.model_dump()
+        self.calls.append(args)
+        return await self._handler(**args)
+
+
+class _FakeTransformService:
+    """Canned Transform MCP tool responses backed by a local HTTP server for the raw byte transfers."""
+
+    def __init__(self, httpserver: HTTPServer, statuses: list[str]):
+        self.statuses = list(statuses)
+        self.file_ref = "u10d://file/test-file-ref"
+        self.job_id = "job-123"
+        self.markdown = "# Sample Document\n\nHello **Markdown** world."
+        self.upload_url = httpserver.url_for("/upload/test-file-ref")
+        self.download_url = httpserver.url_for("/download/test-file-ref")
+
+        httpserver.expect_request("/upload/test-file-ref", method="PUT").respond_with_data("")
+        httpserver.expect_request("/download/test-file-ref",
+                                  method="GET").respond_with_data(self.markdown, content_type="text/markdown")
+
+        async def _request_file_upload_url(**_kwargs) -> str:
+            return json.dumps({
+                "upload_url": self.upload_url,
+                "method": "PUT",
+                "headers": {
+                    "Content-Type": _kwargs.get("content_type", "application/octet-stream")
+                },
+                "file_ref": self.file_ref,
+            })
+
+        async def _transform_files(**_kwargs) -> str:
+            return json.dumps({"job_id": self.job_id, "status": "SCHEDULED"})
+
+        async def _check_transform_status(**_kwargs) -> str:
+            status = self.statuses.pop(0) if len(self.statuses) > 1 else self.statuses[0]
+            return json.dumps({"job_id": self.job_id, "status": status})
+
+        async def _get_transform_results(**_kwargs) -> str:
+            return json.dumps({
+                "job_id":
+                    self.job_id,
+                "files": [{
+                    "filename": "sample.pdf",
+                    "download_url": self.download_url,
+                    "element_count": 12,
+                    "character_count": len(self.markdown),
+                }],
+            })
+
+        self.group_functions = {
+            f"{_GROUP}__request_file_upload_url": _FakeTool("request_file_upload_url", _request_file_upload_url),
+            f"{_GROUP}__transform_files": _FakeTool("transform_files", _transform_files),
+            f"{_GROUP}__check_transform_status": _FakeTool("check_transform_status", _check_transform_status),
+            f"{_GROUP}__get_transform_results": _FakeTool("get_transform_results", _get_transform_results),
+        }
+
+    @property
+    def tools(self) -> TransformTools:
+        """Resolve the fake group into the TransformTools the code under test expects."""
+        return resolve_tools(self.group_functions)  # type: ignore[arg-type]
+
+    def tool(self, name: str) -> _FakeTool:
+        """Return the fake tool registered under the given MCP tool name."""
+        return typing.cast(_FakeTool, self.group_functions[f"{_GROUP}__{name}"])
+
+
+@pytest.fixture(name="fast_config")
+def fast_config_fixture() -> TransformDocumentConfig:
+    """Config with tiny timeouts so the polling paths run quickly in tests."""
+    return TransformDocumentConfig(poll_interval_seconds=0.01, transform_timeout_seconds=5.0, http_timeout_seconds=5.0)
+
+
+@pytest.fixture(name="sample_document")
+def sample_document_fixture(tmp_path: Path) -> Path:
+    """Write a small local file for the upload path to read."""
+    document = tmp_path / "sample.pdf"
+    document.write_bytes(b"%PDF-1.4 fake test document bytes")
+    return document
+
+
+async def test_local_file_transform(httpserver: HTTPServer, fast_config: TransformDocumentConfig,
+                                    sample_document: Path):
+    """A local file is uploaded and transformed, with the expected MCP call shapes and no bearer token on the PUT."""
+    service = _FakeTransformService(httpserver, statuses=["SCHEDULED", "IN_PROGRESS", "COMPLETED"])
+
+    result = await transform_source(service.tools, fast_config, str(sample_document))
+
+    assert result.markdown == service.markdown
+    assert result.element_count == 12
+    assert result.character_count == len(service.markdown)
+    assert result.filename == "sample.pdf"
+
+    upload_request_args = service.tool("request_file_upload_url").calls[0]
+    assert upload_request_args["filename"] == "sample.pdf"
+    assert upload_request_args["content_type"] == "application/pdf"
+    assert upload_request_args["size_bytes"] == sample_document.stat().st_size
+
+    assert service.tool("transform_files").calls == [{"file_refs": [service.file_ref]}]
+    assert all(call == {"job_id": service.job_id} for call in service.tool("check_transform_status").calls)
+    assert service.tool("get_transform_results").calls == [{"job_id": service.job_id}]
+
+    put_requests = [request for request, _ in httpserver.log if request.method == "PUT"]
+    assert len(put_requests) == 1
+    # The pre-signed upload URL must receive the raw bytes without the bearer token.
+    assert "Authorization" not in put_requests[0].headers
+    assert put_requests[0].headers["Content-Type"] == "application/pdf"
+    assert put_requests[0].get_data() == sample_document.read_bytes()
+
+
+async def test_public_url_skips_upload(httpserver: HTTPServer, fast_config: TransformDocumentConfig):
+    """A public URL is passed straight to transform_files, skipping the upload step."""
+    service = _FakeTransformService(httpserver, statuses=["COMPLETED"])
+    url = "https://example.com/whitepaper.pdf"
+
+    result = await transform_source(service.tools, fast_config, url)
+
+    assert result.markdown == service.markdown
+    assert service.tool("request_file_upload_url").calls == []
+    assert service.tool("transform_files").calls == [{"file_refs": [url]}]
+
+
+async def test_failed_job_raises(httpserver: HTTPServer, fast_config: TransformDocumentConfig, sample_document: Path):
+    """A job that ends in a non-success terminal state raises an error naming the state."""
+    service = _FakeTransformService(httpserver, statuses=["FAILED"])
+
+    with pytest.raises(RuntimeError, match="unexpected state 'FAILED'"):
+        await transform_source(service.tools, fast_config, str(sample_document))
+
+
+async def test_poll_timeout_raises(httpserver: HTTPServer, sample_document: Path):
+    """Polling stops with a timeout when the job never completes."""
+    service = _FakeTransformService(httpserver, statuses=["IN_PROGRESS"])
+    config = TransformDocumentConfig(poll_interval_seconds=0.01,
+                                     transform_timeout_seconds=0.05,
+                                     http_timeout_seconds=5.0)
+
+    with pytest.raises(TimeoutError, match="did not complete"):
+        await transform_source(service.tools, config, str(sample_document))
+
+
+async def test_oversized_file_rejected(httpserver: HTTPServer, sample_document: Path):
+    """A file above the size limit is rejected before any upload URL is requested."""
+    service = _FakeTransformService(httpserver, statuses=["COMPLETED"])
+    config = TransformDocumentConfig(poll_interval_seconds=0.01,
+                                     transform_timeout_seconds=5.0,
+                                     http_timeout_seconds=5.0,
+                                     max_file_size_bytes=4)
+
+    with pytest.raises(ValueError, match="exceeds"):
+        await transform_source(service.tools, config, str(sample_document))
+
+    assert service.tool("request_file_upload_url").calls == []
+
+
+async def test_missing_file_rejected(httpserver: HTTPServer, fast_config: TransformDocumentConfig, tmp_path: Path):
+    """A missing local path raises FileNotFoundError."""
+    service = _FakeTransformService(httpserver, statuses=["COMPLETED"])
+
+    with pytest.raises(FileNotFoundError):
+        await transform_source(service.tools, fast_config, str(tmp_path / "does-not-exist.pdf"))
+
+
+async def test_results_not_ready_retries_until_available(httpserver: HTTPServer,
+                                                         fast_config: TransformDocumentConfig,
+                                                         sample_document: Path):
+    """The status endpoint can report COMPLETED slightly before the results exist."""
+    service = _FakeTransformService(httpserver, statuses=["COMPLETED"])
+    real_results_tool = service.tool("get_transform_results")
+    not_ready_responses = 2
+    attempts = []
+
+    async def _flaky_results(**kwargs) -> str:
+        if len(attempts) < not_ready_responses:
+            attempts.append(kwargs)
+            return json.dumps({
+                "error": {
+                    "code": "job_not_complete", "message": "results are available only after the job completes"
+                }
+            })
+        return await real_results_tool._handler(**kwargs)
+
+    service.group_functions[f"{_GROUP}__get_transform_results"] = _FakeTool("get_transform_results", _flaky_results)
+
+    result = await transform_source(service.tools, fast_config, str(sample_document))
+
+    assert len(attempts) == not_ready_responses
+    assert result.markdown == service.markdown
+
+
+async def test_tool_error_payload_raises(httpserver: HTTPServer,
+                                         fast_config: TransformDocumentConfig,
+                                         sample_document: Path):
+    """An error envelope returned by an MCP tool is surfaced as an error."""
+    service = _FakeTransformService(httpserver, statuses=["COMPLETED"])
+
+    async def _unauthorized(**_kwargs) -> str:
+        return json.dumps({"error": {"code": "unauthorized", "message": "Invalid API key", "status": 401}})
+
+    service.group_functions[f"{_GROUP}__transform_files"] = _FakeTool("transform_files", _unauthorized)
+
+    with pytest.raises(RuntimeError, match="unauthorized"):
+        await transform_source(service.tools, fast_config, str(sample_document))
+
+
+async def test_non_json_tool_output_raises(httpserver: HTTPServer,
+                                           fast_config: TransformDocumentConfig,
+                                           sample_document: Path):
+    """Non-JSON tool output raises a descriptive error."""
+    service = _FakeTransformService(httpserver, statuses=["COMPLETED"])
+
+    async def _error_text(**_kwargs) -> str:
+        return "MCPToolClient tool call failed: upstream error"
+
+    service.group_functions[f"{_GROUP}__request_file_upload_url"] = _FakeTool("request_file_upload_url", _error_text)
+
+    with pytest.raises(RuntimeError, match="Expected a JSON payload"):
+        await transform_source(service.tools, fast_config, str(sample_document))
+
+
+def test_resolve_tools_reports_missing(httpserver: HTTPServer):
+    """resolve_tools reports which required tool is absent from the group."""
+    service = _FakeTransformService(httpserver, statuses=["COMPLETED"])
+    del service.group_functions[f"{_GROUP}__get_transform_results"]
+
+    with pytest.raises(ValueError, match="get_transform_results"):
+        resolve_tools(service.group_functions)  # type: ignore[arg-type]
+
+
+def test_workflow_config_loads(monkeypatch: pytest.MonkeyPatch):
+    """The shipped config loads and wires the expected function, group, and workflow types."""
+    from nat.runtime.loader import load_config
+    from nat.test.utils import locate_example_config
+
+    monkeypatch.setenv("UNSTRUCTURED_API_KEY", "test-key-0123456789")
+
+    config = load_config(locate_example_config(TransformDocumentConfig))
+
+    function_config = config.functions["transform_document"]
+    assert isinstance(function_config, TransformDocumentConfig)
+    assert str(function_config.mcp_group) == "unstructured_transform"
+
+    group_config = config.function_groups["unstructured_transform"]
+    assert group_config.server.transport == "streamable-http"
+    assert str(group_config.server.url).rstrip("/") == "https://mcp.transform.unstructured.io"
+    assert str(group_config.server.auth_provider) == "unstructured_auth"
+
+    assert config.workflow.type == "react_agent"
+
+
+# --- Additional error-path coverage for the orchestration core ---
+
+
+async def test_results_error_not_retried(httpserver: HTTPServer,
+                                         fast_config: TransformDocumentConfig,
+                                         sample_document: Path):
+    """A non-retryable error at results-fetch time must raise immediately, not time out."""
+    service = _FakeTransformService(httpserver, statuses=["COMPLETED"])
+
+    async def _unauthorized(**_kwargs) -> str:
+        return json.dumps({"error": {"code": "unauthorized", "message": "Invalid API key", "status": 401}})
+
+    service.group_functions[f"{_GROUP}__get_transform_results"] = _FakeTool("get_transform_results", _unauthorized)
+
+    with pytest.raises(RuntimeError, match="unauthorized"):
+        await transform_source(service.tools, fast_config, str(sample_document))
+
+
+async def test_results_fetch_deadline(httpserver: HTTPServer, sample_document: Path):
+    """Results that never materialize after COMPLETED status hit the shared deadline."""
+    service = _FakeTransformService(httpserver, statuses=["COMPLETED"])
+
+    async def _never_ready(**_kwargs) -> str:
+        return json.dumps({"error": {"code": "job_not_complete", "message": "not yet"}})
+
+    service.group_functions[f"{_GROUP}__get_transform_results"] = _FakeTool("get_transform_results", _never_ready)
+    config = TransformDocumentConfig(poll_interval_seconds=0.01,
+                                     transform_timeout_seconds=0.05,
+                                     http_timeout_seconds=5.0)
+
+    with pytest.raises(TimeoutError, match="did not complete"):
+        await transform_source(service.tools, config, str(sample_document))
+
+
+async def test_empty_files_list_raises(httpserver: HTTPServer,
+                                       fast_config: TransformDocumentConfig,
+                                       sample_document: Path):
+    """A completed job that returns no files raises an error."""
+    service = _FakeTransformService(httpserver, statuses=["COMPLETED"])
+
+    async def _no_files(**_kwargs) -> str:
+        return json.dumps({"job_id": service.job_id, "files": []})
+
+    service.group_functions[f"{_GROUP}__get_transform_results"] = _FakeTool("get_transform_results", _no_files)
+
+    with pytest.raises(RuntimeError, match="returned no files"):
+        await transform_source(service.tools, fast_config, str(sample_document))
+
+
+async def test_missing_required_field_raises(httpserver: HTTPServer,
+                                             fast_config: TransformDocumentConfig,
+                                             sample_document: Path):
+    """A response missing a required field names that field in the error."""
+    service = _FakeTransformService(httpserver, statuses=["COMPLETED"])
+
+    async def _no_file_ref(**kwargs) -> str:
+        return json.dumps({"upload_url": service.upload_url, "method": "PUT", "headers": {}})
+
+    service.group_functions[f"{_GROUP}__request_file_upload_url"] = _FakeTool("request_file_upload_url", _no_file_ref)
+
+    with pytest.raises(RuntimeError, match="'file_ref'"):
+        await transform_source(service.tools, fast_config, str(sample_document))
+
+
+async def test_non_dict_json_payload_raises(httpserver: HTTPServer,
+                                            fast_config: TransformDocumentConfig,
+                                            sample_document: Path):
+    """A JSON payload that is not an object raises a descriptive error."""
+    service = _FakeTransformService(httpserver, statuses=["COMPLETED"])
+
+    async def _json_array(**_kwargs) -> str:
+        return json.dumps([1, 2, 3])
+
+    service.group_functions[f"{_GROUP}__request_file_upload_url"] = _FakeTool("request_file_upload_url", _json_array)
+
+    with pytest.raises(RuntimeError, match="Expected a JSON object"):
+        await transform_source(service.tools, fast_config, str(sample_document))
+
+
+async def test_transient_status_blip_is_retried(httpserver: HTTPServer,
+                                                fast_config: TransformDocumentConfig,
+                                                sample_document: Path):
+    """A momentary transport failure during status polling must not abandon the job."""
+    service = _FakeTransformService(httpserver, statuses=["IN_PROGRESS", "COMPLETED"])
+    real_status_tool = service.tool("check_transform_status")
+    blips = []
+
+    async def _flaky_status(**kwargs) -> str:
+        if not blips:
+            blips.append(True)
+            return "MCPToolClient tool call failed: connection reset"
+        return await real_status_tool._handler(**kwargs)
+
+    service.group_functions[f"{_GROUP}__check_transform_status"] = _FakeTool("check_transform_status", _flaky_status)
+
+    result = await transform_source(service.tools, fast_config, str(sample_document))
+
+    assert result.markdown == service.markdown
+    assert blips == [True]
+
+
+async def test_persistent_status_blips_raise(httpserver: HTTPServer,
+                                             fast_config: TransformDocumentConfig,
+                                             sample_document: Path):
+    """Repeated transport failures during polling give up after the retry limit."""
+    service = _FakeTransformService(httpserver, statuses=["COMPLETED"])
+    attempts = []
+
+    async def _always_broken(**_kwargs) -> str:
+        attempts.append(True)
+        return "MCPToolClient tool call failed: connection reset"
+
+    service.group_functions[f"{_GROUP}__check_transform_status"] = _FakeTool("check_transform_status", _always_broken)
+
+    with pytest.raises(RuntimeError, match="Expected a JSON payload"):
+        await transform_source(service.tools, fast_config, str(sample_document))
+
+    assert len(attempts) == 3
+
+
+async def test_upload_http_error_sanitized(httpserver: HTTPServer,
+                                           fast_config: TransformDocumentConfig,
+                                           sample_document: Path):
+    """A failed pre-signed transfer must not leak the URL signature into the error message."""
+    service = _FakeTransformService(httpserver, statuses=["COMPLETED"])
+    httpserver.clear()
+    httpserver.expect_request("/upload/test-file-ref", method="PUT").respond_with_data("denied", status=403)
+    service.upload_url = httpserver.url_for("/upload/test-file-ref") + "?X-Signature=secret-credential"
+
+    async def _signed_upload(**_kwargs) -> str:
+        return json.dumps({
+            "upload_url": service.upload_url, "method": "PUT", "headers": {}, "file_ref": service.file_ref
+        })
+
+    service.group_functions[f"{_GROUP}__request_file_upload_url"] = _FakeTool("request_file_upload_url", _signed_upload)
+
+    with pytest.raises(RuntimeError, match="document upload failed with HTTP 403") as exc_info:
+        await transform_source(service.tools, fast_config, str(sample_document))
+
+    assert "secret-credential" not in str(exc_info.value)
+    assert "/upload/test-file-ref" in str(exc_info.value)
+
+
+async def test_status_error_envelope_raises(httpserver: HTTPServer,
+                                            fast_config: TransformDocumentConfig,
+                                            sample_document: Path):
+    """A non-retryable status error envelope is surfaced immediately."""
+    service = _FakeTransformService(httpserver, statuses=["COMPLETED"])
+
+    async def _status_error(**_kwargs) -> str:
+        return json.dumps({"error": {"code": "job_not_found", "message": "Job not found", "status": 404}})
+
+    service.group_functions[f"{_GROUP}__check_transform_status"] = _FakeTool("check_transform_status", _status_error)
+
+    with pytest.raises(RuntimeError, match="job_not_found"):
+        await transform_source(service.tools, fast_config, str(sample_document))
+
+
+async def test_transient_results_blip_is_retried(httpserver: HTTPServer,
+                                                 fast_config: TransformDocumentConfig,
+                                                 sample_document: Path):
+    """A momentary transport failure during the results fetch is retried."""
+    service = _FakeTransformService(httpserver, statuses=["COMPLETED"])
+    real_results_tool = service.tool("get_transform_results")
+    blips = []
+
+    async def _flaky_results(**kwargs) -> str:
+        if not blips:
+            blips.append(True)
+            return "MCPToolClient tool call failed: connection reset"
+        return await real_results_tool._handler(**kwargs)
+
+    service.group_functions[f"{_GROUP}__get_transform_results"] = _FakeTool("get_transform_results", _flaky_results)
+
+    result = await transform_source(service.tools, fast_config, str(sample_document))
+
+    assert result.markdown == service.markdown
+    assert blips == [True]
+
+
+async def test_non_dict_files_entry_raises(httpserver: HTTPServer,
+                                           fast_config: TransformDocumentConfig,
+                                           sample_document: Path):
+    """A files entry that is not a mapping raises a descriptive error."""
+    service = _FakeTransformService(httpserver, statuses=["COMPLETED"])
+
+    async def _string_files(**_kwargs) -> str:
+        return json.dumps({"job_id": service.job_id, "files": ["not-a-mapping"]})
+
+    service.group_functions[f"{_GROUP}__get_transform_results"] = _FakeTool("get_transform_results", _string_files)
+
+    with pytest.raises(RuntimeError, match="unexpected files entry"):
+        await transform_source(service.tools, fast_config, str(sample_document))
+
+
+# --- The registered function: agent-facing wrapper contract ---
+
+
+class _StubGroup:
+    """Minimal function group that exposes the fake tools to the registered function."""
+
+    def __init__(self, group_functions: dict[str, _FakeTool]):
+        self._group_functions = group_functions
+
+    async def get_accessible_functions(self) -> dict[str, _FakeTool]:
+        """Return the fake group's functions."""
+        return self._group_functions
+
+
+class _StubBuilder:
+    """Minimal builder that hands the registered function its function group."""
+
+    def __init__(self, group: _StubGroup):
+        self._group = group
+
+    async def get_function_group(self, _name) -> _StubGroup:
+        """Return the stub group regardless of the requested name."""
+        return self._group
+
+
+@asynccontextmanager
+async def _registered_transform_fn(service: _FakeTransformService, config: TransformDocumentConfig):
+    """Drive the registered async generator exactly as the workflow builder would."""
+    builder = _StubBuilder(_StubGroup(service.group_functions))
+    async with transform_document(config, builder) as info:  # type: ignore[arg-type]
+        yield info.single_fn
+
+
+async def test_registered_function_happy_path(httpserver: HTTPServer,
+                                              fast_config: TransformDocumentConfig,
+                                              sample_document: Path):
+    """The registered tool returns the transformed Markdown on success."""
+    service = _FakeTransformService(httpserver, statuses=["SCHEDULED", "COMPLETED"])
+
+    async with _registered_transform_fn(service, fast_config) as transform_fn:
+        output = await transform_fn(str(sample_document))
+
+    assert output == service.markdown
+
+
+async def test_registered_function_returns_error_string(httpserver: HTTPServer,
+                                                        fast_config: TransformDocumentConfig,
+                                                        tmp_path: Path):
+    """Failures must reach the agent as a readable tool result, never as an exception."""
+    service = _FakeTransformService(httpserver, statuses=["COMPLETED"])
+    missing = tmp_path / "does-not-exist.pdf"
+
+    async with _registered_transform_fn(service, fast_config) as transform_fn:
+        output = await transform_fn(str(missing))
+
+    assert output.startswith("ERROR: failed to transform")
+    assert str(missing) in output
+
+
+async def test_registered_function_truncates_output(httpserver: HTTPServer, sample_document: Path):
+    """Output longer than the limit is truncated and a notice is appended."""
+    service = _FakeTransformService(httpserver, statuses=["COMPLETED"])
+    config = TransformDocumentConfig(poll_interval_seconds=0.01,
+                                     transform_timeout_seconds=5.0,
+                                     http_timeout_seconds=5.0,
+                                     max_output_characters=10)
+
+    async with _registered_transform_fn(service, config) as transform_fn:
+        output = await transform_fn(str(sample_document))
+
+    assert output.startswith(service.markdown[:10])
+    assert "[Output truncated at 10 characters" in output
+
+
+async def test_registered_function_no_truncation_at_boundary(httpserver: HTTPServer, sample_document: Path):
+    """Output exactly at the limit is returned untruncated."""
+    service = _FakeTransformService(httpserver, statuses=["COMPLETED"])
+    config = TransformDocumentConfig(poll_interval_seconds=0.01,
+                                     transform_timeout_seconds=5.0,
+                                     http_timeout_seconds=5.0,
+                                     max_output_characters=len(service.markdown))
+
+    async with _registered_transform_fn(service, config) as transform_fn:
+        output = await transform_fn(str(sample_document))
+
+    assert output == service.markdown

--- a/examples/unstructured_transform_mcp/tests/test_workflow_integration.py
+++ b/examples/unstructured_transform_mcp/tests/test_workflow_integration.py
@@ -1,0 +1,129 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Integration tests against the live Unstructured Transform MCP server.
+
+These tests require the `UNSTRUCTURED_API_KEY` environment variable (get a key from
+https://transform.unstructured.io/get-started) and are skipped otherwise. The full
+workflow test additionally requires `NVIDIA_API_KEY` for the NIM LLM.
+
+Run with:
+    pytest --run_integration --run_slow examples/unstructured_transform_mcp/tests
+"""
+
+from pathlib import Path
+
+import pytest
+
+from nat.test.plugin import require_env_variables
+
+_MAGIC_SENTENCE = "The magic word is xylophone."
+
+
+@pytest.fixture(name="unstructured_api_key")
+def unstructured_api_key_fixture(fail_missing: bool):
+    """Skip the test unless an Unstructured Transform API key is available."""
+    yield require_env_variables(
+        varnames=["UNSTRUCTURED_API_KEY"],
+        reason="Unstructured integration tests require the `UNSTRUCTURED_API_KEY` environment variable",
+        fail_missing=fail_missing)
+
+
+def _build_minimal_pdf(text: str) -> bytes:
+    """Build a tiny single-page PDF containing the given text, with no extra dependencies."""
+    stream = f"BT /F1 18 Tf 72 720 Td ({text}) Tj ET".encode()
+    objects = [
+        b"<< /Type /Catalog /Pages 2 0 R >>",
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R "
+        b"/Resources << /Font << /F1 5 0 R >> >> >>",
+        b"<< /Length " + str(len(stream)).encode() + b" >>\nstream\n" + stream + b"\nendstream",
+        b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+    ]
+
+    pdf = bytearray(b"%PDF-1.4\n")
+    offsets = []
+    for index, body in enumerate(objects, start=1):
+        offsets.append(len(pdf))
+        pdf += f"{index} 0 obj\n".encode() + body + b"\nendobj\n"
+
+    xref_offset = len(pdf)
+    pdf += f"xref\n0 {len(objects) + 1}\n".encode()
+    pdf += b"0000000000 65535 f \n"
+    for offset in offsets:
+        pdf += f"{offset:010d} 00000 n \n".encode()
+    pdf += f"trailer\n<< /Size {len(objects) + 1} /Root 1 0 R >>\nstartxref\n{xref_offset}\n%%EOF\n".encode()
+    return bytes(pdf)
+
+
+@pytest.fixture(name="sample_pdf")
+def sample_pdf_fixture(tmp_path: Path) -> Path:
+    """Write a one-page PDF containing the magic-word sentence for the live transform."""
+    pdf_path = tmp_path / "magic_word.pdf"
+    pdf_path.write_bytes(_build_minimal_pdf(_MAGIC_SENTENCE))
+    return pdf_path
+
+
+@pytest.mark.slow
+@pytest.mark.integration
+@pytest.mark.timeout(700)
+@pytest.mark.usefixtures("unstructured_api_key")
+async def test_transform_document_function_live(sample_pdf: Path):
+    """Exercise the transform_document function against the live server, without an LLM.
+
+    The authentication provider and MCP client group are taken from the shipped workflow
+    configuration so this test cannot drift from the example (server URL included);
+    loading the configuration also interpolates ``UNSTRUCTURED_API_KEY`` from the
+    environment exactly as `nat run` would.
+    """
+    from nat.builder.workflow_builder import WorkflowBuilder
+    from nat.runtime.loader import load_config
+    from nat.test.utils import locate_example_config
+    from nat_unstructured_transform_mcp.register import TransformDocumentConfig
+    from nat_unstructured_transform_mcp.register import resolve_tools
+    from nat_unstructured_transform_mcp.register import transform_source
+
+    shipped_config = load_config(locate_example_config(TransformDocumentConfig))
+
+    async with WorkflowBuilder() as builder:
+        await builder.add_auth_provider("unstructured_auth", shipped_config.authentication["unstructured_auth"])
+        group = await builder.add_function_group("unstructured_transform",
+                                                 shipped_config.function_groups["unstructured_transform"])
+
+        tools = resolve_tools(await group.get_accessible_functions())
+        config = TransformDocumentConfig(poll_interval_seconds=3.0, transform_timeout_seconds=600.0)
+
+        result = await transform_source(tools, config, str(sample_pdf))
+
+    assert result.markdown.strip(), "Expected non-empty Markdown output"
+    assert result.element_count > 0, "Expected a non-zero element count"
+    assert "xylophone" in result.markdown.lower()
+
+
+@pytest.mark.slow
+@pytest.mark.integration
+@pytest.mark.timeout(1000)
+@pytest.mark.usefixtures("nvidia_api_key", "unstructured_api_key")
+async def test_full_workflow_live(sample_pdf: Path):
+    """Run the complete agent workflow end-to-end against the live server."""
+    from nat.test.utils import locate_example_config
+    from nat.test.utils import run_workflow
+    from nat_unstructured_transform_mcp.register import TransformDocumentConfig
+
+    config_file = locate_example_config(TransformDocumentConfig)
+
+    await run_workflow(config_file=config_file,
+                       question=(f"Use the transform_document tool to convert the document at {sample_pdf} "
+                                 "to Markdown, then answer: what is the magic word in the document?"),
+                       expected_answer="xylophone")


### PR DESCRIPTION
## Description

Adds a community example demonstrating a NeMo Agent Toolkit agent connecting to a remote, third-party MCP server protected by static bearer-token authentication (the built-in `api_key` provider with `auth_scheme: Bearer`). The server is the hosted Unstructured Transform service, which parses documents into Markdown. A single deterministic `transform_document` function wraps the server's asynchronous upload/transform/poll/download protocol, so the ReAct agent needs one reliable tool call.

This is the example @willkill07 redirected here from NVIDIA/NeMo-Agent-Toolkit#2109. It follows the `kaggle_mcp` pattern (a remote MCP server over streamable-http, bearer auth via the built-in provider) and targets nvidia-nat 1.8.

What's included:
- `examples/unstructured_transform_mcp/` with `pyproject.toml`, `configs/config.yml`, `src/nat_unstructured_transform_mcp/register.py`, a README, and unit plus integration tests.
- Two terms (`streamable`, `untrusted`) added to the Vale vocabulary for the README.

Verification:
- `uv pip install -e examples/unstructured_transform_mcp` resolves nvidia-nat 1.8.0 from PyPI.
- 26 unit tests pass; the 2 integration tests are skipped unless `UNSTRUCTURED_API_KEY` is set.
- `./ci/scripts/checks.sh` passes (pre-commit, copyright, Vale).

Closes #28

## By Submitting this PR I confirm:
- I am familiar with the Contributing Guidelines.
- All commits are signed off (DCO).